### PR TITLE
Update template.yml

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -35,7 +35,7 @@ Resources:
       Runtime: python3.8
       CodeUri: src/
       Handler: handler.lambda_handler
-      FunctionName: NewRelic-s3-log-ingestion
+      FunctionName: NewRelic-s3-log-ingestion-jboss
       Timeout: 900
       MemorySize: 256
       Environment:


### PR DESCRIPTION
appended "-jboss" to FunctionName, so AWS Lambda function doesn't conflict with the default.  This allows me to create a 2nd instance of "NewRelic-s3-log-ingestion" for a different logtype (original one is used for apache)